### PR TITLE
fix: remove `vite.config.js`

### DIFF
--- a/preset.ts
+++ b/preset.ts
@@ -62,7 +62,7 @@ async function installVite(https: boolean) {
 
 			await deletePaths({
 				title: 'remove some default files',
-				paths: ['resources/js', 'resources/css', 'webpack.mix.js'],
+				paths: ['resources/js', 'resources/css', 'webpack.mix.js', 'vite.config.js'],
 			})
 
 			await editFiles({


### PR DESCRIPTION
Laravel 9.19 integrates vitejs support, and there is a conflict between the original `vite.config.js` and `vite.config.ts` provided by this preset.
Signed-off-by: Eric Villard <dev@eviweb.fr>